### PR TITLE
Removing "os" library call out from CondaDependencies.

### DIFF
--- a/ScriptRunConfig.py
+++ b/ScriptRunConfig.py
@@ -6,7 +6,7 @@ ws = Workspace.from_config()
 sklearn_env = Environment("sklearn-env")
 
 # Ensure the required packages are installed
-packages = CondaDependencies.create(conda_packages=['scikit-learn', 'pandas', 'numpy', 'os', 'joblib', 'pip'],
+packages = CondaDependencies.create(conda_packages=['scikit-learn', 'pandas', 'numpy', 'joblib', 'pip'],
                                     pip_packages=['azureml-defaults'])
 sklearn_env.python.conda_dependencies = packages
 


### PR DESCRIPTION
 I am removing the os library from the CondaDpendencies.create(conda_packages='') call because that library may already exist on the Microsoft Azure deployment.

When running ScriptRunConfig, this error appears:
```
PackagesNotFoundError: The following packages are not available from current channels:
  - os
```

This may already exist on Python AzureML image by default. This fix attempt is to find out.